### PR TITLE
오브젝트 생성시 사운드 규칙 추가 yeet!

### DIFF
--- a/Assets/Enemy/PrePab/Fly/AttackFly.prefab
+++ b/Assets/Enemy/PrePab/Fly/AttackFly.prefab
@@ -472,7 +472,7 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1
   MinDistance: 1
-  MaxDistance: 5
+  MaxDistance: 3.5
   Pan2D: 0
   rolloffMode: 2
   BypassEffects: 0

--- a/Assets/Enemy/PrePab/Fly/Moter.prefab
+++ b/Assets/Enemy/PrePab/Fly/Moter.prefab
@@ -656,7 +656,7 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1
   MinDistance: 1
-  MaxDistance: 5
+  MaxDistance: 3.5
   Pan2D: 0
   rolloffMode: 2
   BypassEffects: 0

--- a/Assets/Enemy/PrePab/Fly/Pooter.prefab
+++ b/Assets/Enemy/PrePab/Fly/Pooter.prefab
@@ -343,7 +343,7 @@ AudioSource:
   Priority: 128
   DopplerLevel: 1
   MinDistance: 1
-  MaxDistance: 5
+  MaxDistance: 3.5
   Pan2D: 0
   rolloffMode: 2
   BypassEffects: 0

--- a/Assets/Enemy/Script/Boss/Gurdy.cs
+++ b/Assets/Enemy/Script/Boss/Gurdy.cs
@@ -177,7 +177,10 @@ public class Gurdy : TEnemy
 
         // SoundManage의 sfxObject로 추가.
         if (obj.GetComponent<AudioSource>() != null)
-            SoundManager.instance.sfxObjects.Add(obj.GetComponent<AudioSource>());
+        {
+            SoundManager.instance.sfxDestoryObjects.Add(obj.GetComponent<AudioSource>());
+            obj.GetComponent<AudioSource>().volume = SoundManager.instance.GetSFXVolume();
+        }
 
         roomInfo.GetComponent<Room>().enemis.Add(obj);
     }

--- a/Assets/Enemy/Script/Fly/Moter.cs
+++ b/Assets/Enemy/Script/Fly/Moter.cs
@@ -59,7 +59,7 @@ public class Moter : TEnemy
         // SoundManage의 sfxObject로 추가.
         if (obj.GetComponent<AudioSource>() != null)
         {
-            SoundManager.instance.sfxObjects.Add(obj.GetComponent<AudioSource>());
+            SoundManager.instance.sfxDestoryObjects.Add(obj.GetComponent<AudioSource>());
             obj.GetComponent<AudioSource>().volume = SoundManager.instance.GetSFXVolume();
         }    
 

--- a/Assets/Item/Active/19_The Poop_OK/GoldenPoop.cs
+++ b/Assets/Item/Active/19_The Poop_OK/GoldenPoop.cs
@@ -13,7 +13,6 @@ public class GoldenPoop : MonoBehaviour
     {
         col = gameObject.GetComponent<Collider2D>();
         col.isTrigger = true;
-        gameObject.GetComponent<AudioSource>().volume = SoundManager.instance.GetSFXVolume();
     }
 
     //생성 시 물리 충돌 X, 똥 Collider 벗어나면 충돌 O
@@ -37,6 +36,7 @@ public class GoldenPoop : MonoBehaviour
     }
     void DestorySound()
     {
+        gameObject.GetComponent<AudioSource>().volume = SoundManager.instance.GetSFXVolume();
         gameObject.GetComponent<AudioSource>().Play();
     }
 }

--- a/Assets/Item/ItemTable.cs
+++ b/Assets/Item/ItemTable.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Unity.VisualScripting;
 using UnityEngine;
 
 public class ItemTable : MonoBehaviour
@@ -58,7 +59,7 @@ public class ItemTable : MonoBehaviour
         keyPool = new Stack<GameObject>();
 
         // 오브젝트 생성
-        for(int i = 0; i < 10; i++)
+        for(int i = 0; i < 40; i++)
         {
             CreateCoin();
             CreateHeart();
@@ -72,7 +73,6 @@ public class ItemTable : MonoBehaviour
         GameObject coin = Instantiate(DropItems[0], dropItemPool_Transform.position, Quaternion.identity);
         coin.transform.SetParent(dropItemPool_Transform);
         coinPool.Push(coin);
-        SetSFXObject(coin);
         coin.SetActive(false);
     }
 
@@ -81,7 +81,6 @@ public class ItemTable : MonoBehaviour
         GameObject heart = Instantiate(DropItems[1], dropItemPool_Transform.position, Quaternion.identity);
         heart.transform.SetParent(dropItemPool_Transform);
         heartPool.Push(heart);
-        SetSFXObject(heart);
         heart.SetActive(false);
     }
 
@@ -90,7 +89,6 @@ public class ItemTable : MonoBehaviour
         GameObject bomb = Instantiate(DropItems[2], dropItemPool_Transform.position, Quaternion.identity);
         bomb.transform.SetParent(dropItemPool_Transform);
         bombPool.Push(bomb);
-        SetSFXObject(bomb);
         bomb.SetActive(false);
     }
 
@@ -99,7 +97,6 @@ public class ItemTable : MonoBehaviour
         GameObject key = Instantiate(DropItems[3], dropItemPool_Transform.position, Quaternion.identity);
         key.transform.SetParent(dropItemPool_Transform);
         keyPool.Push(key);
-        SetSFXObject(key);
         key.SetActive(false);
     }
     #endregion
@@ -354,16 +351,6 @@ public class ItemTable : MonoBehaviour
     {
         return PassiveItems[index].GetComponent<SpriteRenderer>().sprite;
     }
-
-    void SetSFXObject(GameObject obj)
-    {
-        // 매개변수로 받은 오브젝트에 오디오소스가 있는지 확인후 sfxobject로 등록
-        if(obj.GetComponent<AudioSource>() != null)
-        {
-            SoundManager.instance.sfxObjects.Add(obj.GetComponent<AudioSource>());
-        }
-    }
-
     #region archive
     public GameObject ObjectBreak() // 오브젝트 부쉈을때
     {

--- a/Assets/Script/Player Script/PlayerController.cs
+++ b/Assets/Script/Player Script/PlayerController.cs
@@ -179,6 +179,7 @@ public class PlayerController : MonoBehaviour
         {
             GameObject tearObj = Instantiate(tear, tearPointTransform.position, Quaternion.identity);
             tearPool.Push(tearObj);
+            SetSFXObject(tearObj);
             tearObj.transform.SetParent(tearPoint.transform);
             tearObj.gameObject.SetActive(false);
         }
@@ -189,6 +190,8 @@ public class PlayerController : MonoBehaviour
         {
             GameObject tearObj = Instantiate(tear, tearPointTransform.position, Quaternion.identity);
             tearPool.Push(tearObj);
+            SetSFXObject(tearObj);
+            tearObj.GetComponent<AudioSource>().volume = SoundManager.instance.GetSFXVolume();
             tearObj.transform.SetParent(tearPoint.transform);
             tearObj.gameObject.SetActive(false);
         }
@@ -790,6 +793,14 @@ public class PlayerController : MonoBehaviour
     {
         audioSource.clip = getItemClip;
         audioSource.Play();
+    }
+
+    void SetSFXObject(GameObject obj)
+    {
+        if(obj.GetComponent<AudioSource>() != null)
+        {
+            SoundManager.instance.sfxObjects.Add(obj.GetComponent<AudioSource>());
+        }
     }
     #endregion
 }

--- a/Assets/Script/Player Script/Tear.cs
+++ b/Assets/Script/Player Script/Tear.cs
@@ -26,11 +26,15 @@ public class Tear : MonoBehaviour
 
     void Start()
     {
-        audioSource = GetComponent<AudioSource>();
+        AudioInit();
         tearBoomAnim = GetComponent<Animator>();
         tearRB = GetComponent<Rigidbody2D>();
+    }
+
+    void AudioInit()
+    {
+        audioSource = GetComponent<AudioSource>();
         audioSource.volume = SoundManager.instance.GetSFXVolume(); // 볼륨 설정
-        ShootSound(); // shoot 사운드 실행
     }
 
     void Update()
@@ -161,6 +165,13 @@ public class Tear : MonoBehaviour
     {
         audioSource.clip = shootSound;
         audioSource.Play();
+    }
+
+    private void OnEnable()
+    {
+        if(audioSource == null)
+            AudioInit();
+        ShootSound();
     }
     #endregion
 }


### PR DESCRIPTION
오브젝트 풀링 및 생성시 사운드 변경사항
1. 기본적으로 생성할때 풀링오브젝트는 sfxObject  풀링오브젝트가 아닌건 sfxDestoryObject 에 add 해줌
2. 맵 생성할때 같이 생성되는 오브젝트들은 따로 볼륨조절이 필요없지만 맵생성이후 게임 플레이 도중에 생성되는 오브젝트들은 sfxObject / sfxDestoryObject에 add 해줄때 볼륨초기화도 같이 해주어야함.
  * 새로 생성된 오브젝트들은 사운드가 1로 초기화된상태로 생성되기때문에 초기화작업을 해줘야함. ex ) 추가로 생성되는 총알 / 추가로 생성되는 픽업아이템4종 / 몬스터가 생성하는 몬스터  등등 (지금까지 확인된것)