### PR TITLE
오브젝트 드랍템 복사 버그 수정

### DIFF
--- a/Assets/Script/StageScript/Object/FirePlace.cs
+++ b/Assets/Script/StageScript/Object/FirePlace.cs
@@ -46,17 +46,22 @@ public class FirePlace : Obstacle
 
     public override void GetDamage()
     {
+        if (spriteIndex > 4)
+            return;
+
         spriteIndex++;
         ChangeObjectSPrite();
-        if (spriteIndex >= 3)
+        if (spriteIndex >= 4)
         {
-            DestorySound();
-
-            DropItem();
-            eft.SetActive(false);
             gameObject.GetComponent<SpriteRenderer>().sprite = woodSprite;
             gameObject.layer = noCollisionLayer;
+
+            DestorySound();
+
+            eft.SetActive(false);
             boxCollider.SetActive(false);
+
+            DropItem();
         }
     }
 

--- a/Assets/Script/StageScript/Object/Poop.cs
+++ b/Assets/Script/StageScript/Object/Poop.cs
@@ -32,12 +32,17 @@ public class Poop : Obstacle
 
     public override void GetDamage()
     {
+        if (spriteIndex > 4)
+            return;
+
         spriteIndex++;
         ChangeObjectSPrite();
         if(spriteIndex >= 4) // 체력이 전부 깍이면
         {
-            DestorySound();
             gameObject.layer = noCollisionLayer;
+
+            DestorySound();
+
             DropItem();
         }
     }
@@ -46,6 +51,7 @@ public class Poop : Obstacle
     {
         if (spriteIndex >= 4)
             spriteIndex = 4;
+
         gameObject.GetComponent<SpriteRenderer>().sprite = poopSprite[spriteIndex];
     }
 

--- a/Assets/Script/StageScript/Object/Rock.cs
+++ b/Assets/Script/StageScript/Object/Rock.cs
@@ -30,7 +30,9 @@ public class Rock : Obstacle
 
     public override void GetDamage()
     {
-        spriteIndex++;
+        if (spriteIndex == 1)
+            return;
+        spriteIndex = 1;
         ChangeObjectSPrite();
         gameObject.layer = noCollisionLayer;
 


### PR DESCRIPTION
1. 불,똥 오브젝트 동시에 타격이 여러번 들어가면 아이템이 타격수만큼 드랍되는버그 수정
2. 돌 오브젝트 동시에 타격이 여러번 들어가면 돌 스프라이트 번호를 초과하여 오류메세지가 발생하는 버그 수정